### PR TITLE
Fix docstrings for Pickle and YAML classes

### DIFF
--- a/src/yaml_to_disk/file_types/pkl.py
+++ b/src/yaml_to_disk/file_types/pkl.py
@@ -6,7 +6,7 @@ from .base import FileType
 
 
 class PickleFile(FileType):
-    """A class for validating and writing JSON files.
+    """A class for validating and writing Pickle files.
 
     Examples:
         >>> with tempfile.NamedTemporaryFile() as tmp_file:

--- a/src/yaml_to_disk/file_types/yaml.py
+++ b/src/yaml_to_disk/file_types/yaml.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 class YAMLFile(FileType):
-    """A class for validating and writing JSON files.
+    """A class for validating and writing YAML files.
 
     Examples:
         >>> with tempfile.NamedTemporaryFile() as tmp_file:


### PR DESCRIPTION
## Summary
- clarify PickleFile docstring to describe Pickle files
- clarify YAMLFile docstring to describe YAML files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f3213aac832c9c720315e3400b86