### PR TITLE
Add matcher docs using .matches

### DIFF
--- a/src/yaml_to_disk/file_types/csv.py
+++ b/src/yaml_to_disk/file_types/csv.py
@@ -163,6 +163,13 @@ class CSVFile(FileType):
         Traceback (most recent call last):
             ...
         TypeError: Contents must be a string, dict, or list; got <class 'int'>
+
+    ``CSVFile.matches`` can detect ``.csv`` file names:
+
+        >>> CSVFile.matches(Path('foo.csv'))
+        True
+        >>> CSVFile.matches(Path('foo.txt'))
+        False
     """
 
     extension: ClassVar[str] = ".csv"

--- a/src/yaml_to_disk/file_types/json.py
+++ b/src/yaml_to_disk/file_types/json.py
@@ -25,6 +25,13 @@ class JSONFile(FileType):
         Traceback (most recent call last):
             ...
         TypeError: Object of type set is not JSON serializable
+
+    ``JSONFile.matches`` can detect ``.json`` file names:
+
+        >>> JSONFile.matches(Path('foo.json'))
+        True
+        >>> JSONFile.matches(Path('foo.txt'))
+        False
     """
 
     extension: ClassVar[str] = ".json"

--- a/src/yaml_to_disk/file_types/parquet.py
+++ b/src/yaml_to_disk/file_types/parquet.py
@@ -55,6 +55,13 @@ class ParquetFile(FileType):
         Traceback (most recent call last):
         ...
         ValueError: Column-maps must have all lists of the same length 2; got b (1)
+
+    ``ParquetFile.matches`` can detect ``.parquet`` file names:
+
+        >>> ParquetFile.matches(Path('foo.parquet'))
+        True
+        >>> ParquetFile.matches(Path('foo.txt'))
+        False
     """
 
     extension: ClassVar[str] = ".parquet"

--- a/src/yaml_to_disk/file_types/pkl.py
+++ b/src/yaml_to_disk/file_types/pkl.py
@@ -27,6 +27,13 @@ class PickleFile(FileType):
         Traceback (most recent call last):
             ...
         _pickle.PicklingError: Can't pickle <function <lambda> at ...>: ...
+
+    ``PickleFile.matches`` can detect ``.pkl`` file names:
+
+        >>> PickleFile.matches(Path('foo.pkl'))
+        True
+        >>> PickleFile.matches(Path('foo.txt'))
+        False
     """
 
     extension: ClassVar[str] = ".pkl"

--- a/src/yaml_to_disk/file_types/toml.py
+++ b/src/yaml_to_disk/file_types/toml.py
@@ -39,6 +39,13 @@ class TOMLFile(FileType):
         Traceback (most recent call last):
         ...
         AttributeError: 'set' object has no attribute 'items'
+
+    ``TOMLFile.matches`` can detect ``.toml`` file names:
+
+        >>> TOMLFile.matches(Path('foo.toml'))
+        True
+        >>> TOMLFile.matches(Path('foo.txt'))
+        False
     """
 
     extension: ClassVar[str] = ".toml"

--- a/src/yaml_to_disk/file_types/tsv.py
+++ b/src/yaml_to_disk/file_types/tsv.py
@@ -18,6 +18,14 @@ class TSVFile(CSVFile):
         Name\tAge
         Alice\t30
         Bob\t25
+
+    ``TSVFile.matches`` can detect ``.tsv`` file names:
+
+        >>> from pathlib import Path
+        >>> TSVFile.matches(Path('foo.tsv'))
+        True
+        >>> TSVFile.matches(Path('foo.txt'))
+        False
     """
 
     extension: ClassVar[str] = ".tsv"

--- a/src/yaml_to_disk/file_types/txt.py
+++ b/src/yaml_to_disk/file_types/txt.py
@@ -21,6 +21,13 @@ class TextFile(FileType):
         Traceback (most recent call last):
             ...
         ValueError: Contents must be a string; got <class 'int'>
+
+    ``TextFile.matches`` can detect ``.txt`` file names:
+
+        >>> TextFile.matches(Path('foo.txt'))
+        True
+        >>> TextFile.matches(Path('foo.json'))
+        False
     """
 
     extension: ClassVar[str] = ".txt"

--- a/src/yaml_to_disk/file_types/yaml.py
+++ b/src/yaml_to_disk/file_types/yaml.py
@@ -38,7 +38,6 @@ class YAMLFile(FileType):
         True
         >>> YAMLFile.matches(Path("foo.txt"))
         False
-
     """
 
     extension: ClassVar[frozenset[str]] = frozenset({".yaml", ".yml"})

--- a/src/yaml_to_disk/file_types/yaml.py
+++ b/src/yaml_to_disk/file_types/yaml.py
@@ -38,6 +38,7 @@ class YAMLFile(FileType):
         True
         >>> YAMLFile.matches(Path("foo.txt"))
         False
+
     """
 
     extension: ClassVar[frozenset[str]] = frozenset({".yaml", ".yml"})

--- a/tests/test_file_type_matcher.py
+++ b/tests/test_file_type_matcher.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pytest
+
+from yaml_to_disk.file_matchers import FILE_TYPE_MATCHER
+from yaml_to_disk.file_types.csv import CSVFile
+from yaml_to_disk.file_types.json import JSONFile
+
+
+def test_file_type_matcher_known_extensions():
+    assert FILE_TYPE_MATCHER('.json').__name__ == JSONFile.__name__
+    assert FILE_TYPE_MATCHER(Path('foo.csv')).__name__ == CSVFile.__name__
+
+
+def test_file_type_matcher_unknown_extension():
+    with pytest.raises(ValueError):
+        FILE_TYPE_MATCHER('.unknown')

--- a/tests/test_file_type_matcher.py
+++ b/tests/test_file_type_matcher.py
@@ -8,10 +8,10 @@ from yaml_to_disk.file_types.json import JSONFile
 
 
 def test_file_type_matcher_known_extensions():
-    assert FILE_TYPE_MATCHER('.json').__name__ == JSONFile.__name__
-    assert FILE_TYPE_MATCHER(Path('foo.csv')).__name__ == CSVFile.__name__
+    assert FILE_TYPE_MATCHER(".json").__name__ == JSONFile.__name__
+    assert FILE_TYPE_MATCHER(Path("foo.csv")).__name__ == CSVFile.__name__
 
 
 def test_file_type_matcher_unknown_extension():
     with pytest.raises(ValueError):
-        FILE_TYPE_MATCHER('.unknown')
+        FILE_TYPE_MATCHER(".unknown")

--- a/tests/test_tabular_utils.py
+++ b/tests/test_tabular_utils.py
@@ -4,7 +4,7 @@ from yaml_to_disk.tabular_utils import validate_column_map, validate_row_map_lis
 
 
 def test_validate_column_map_valid():
-    validate_column_map({'a': [1, 2], 'b': [3, 4]})
+    validate_column_map({"a": [1, 2], "b": [3, 4]})
 
 
 def test_validate_column_map_bad_key():
@@ -14,21 +14,21 @@ def test_validate_column_map_bad_key():
 
 def test_validate_column_map_bad_value():
     with pytest.raises(ValueError):
-        validate_column_map({'a': 'x'})
+        validate_column_map({"a": "x"})
 
 
 def test_validate_column_map_bad_length():
     with pytest.raises(ValueError):
-        validate_column_map({'a': [1, 2], 'b': [3]})
+        validate_column_map({"a": [1, 2], "b": [3]})
 
 
 def test_validate_row_map_list_valid():
-    rows = [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]
-    assert validate_row_map_list(rows) == ['a', 'b']
+    rows = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+    assert validate_row_map_list(rows) == ["a", "b"]
 
 
 def test_validate_row_map_list_inconsistent():
-    rows = [{'a': 1, 'b': 2}, {'a': 3}]
+    rows = [{"a": 1, "b": 2}, {"a": 3}]
     with pytest.raises(ValueError):
         validate_row_map_list(rows)
 

--- a/tests/test_tabular_utils.py
+++ b/tests/test_tabular_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from yaml_to_disk.tabular_utils import validate_column_map, validate_row_map_list
+
+
+def test_validate_column_map_valid():
+    validate_column_map({'a': [1, 2], 'b': [3, 4]})
+
+
+def test_validate_column_map_bad_key():
+    with pytest.raises(ValueError):
+        validate_column_map({1: [1, 2]})
+
+
+def test_validate_column_map_bad_value():
+    with pytest.raises(ValueError):
+        validate_column_map({'a': 'x'})
+
+
+def test_validate_column_map_bad_length():
+    with pytest.raises(ValueError):
+        validate_column_map({'a': [1, 2], 'b': [3]})
+
+
+def test_validate_row_map_list_valid():
+    rows = [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]
+    assert validate_row_map_list(rows) == ['a', 'b']
+
+
+def test_validate_row_map_list_inconsistent():
+    rows = [{'a': 1, 'b': 2}, {'a': 3}]
+    with pytest.raises(ValueError):
+        validate_row_map_list(rows)
+
+
+def test_validate_row_map_list_bad_key():
+    with pytest.raises(ValueError):
+        validate_row_map_list([{1: 2}])

--- a/tests/test_yaml_disk_e2e.py
+++ b/tests/test_yaml_disk_e2e.py
@@ -5,10 +5,10 @@ from yaml_to_disk import yaml_disk
 
 def test_yaml_disk_end_to_end():
     yaml_data = {
-        'sub/': {'a.txt': 'hello'},
-        'b.json': {'foo': 'bar'},
+        "sub/": {"a.txt": "hello"},
+        "b.json": {"foo": "bar"},
     }
     with yaml_disk(yaml_data) as root:
-        assert (root / 'sub' / 'a.txt').read_text() == 'hello'
-        assert json.loads((root / 'b.json').read_text()) == {'foo': 'bar'}
+        assert (root / "sub" / "a.txt").read_text() == "hello"
+        assert json.loads((root / "b.json").read_text()) == {"foo": "bar"}
     assert not root.exists()

--- a/tests/test_yaml_disk_e2e.py
+++ b/tests/test_yaml_disk_e2e.py
@@ -1,0 +1,14 @@
+import json
+
+from yaml_to_disk import yaml_disk
+
+
+def test_yaml_disk_end_to_end():
+    yaml_data = {
+        'sub/': {'a.txt': 'hello'},
+        'b.json': {'foo': 'bar'},
+    }
+    with yaml_disk(yaml_data) as root:
+        assert (root / 'sub' / 'a.txt').read_text() == 'hello'
+        assert json.loads((root / 'b.json').read_text()) == {'foo': 'bar'}
+    assert not root.exists()

--- a/tests/test_yaml_disk_internal.py
+++ b/tests/test_yaml_disk_internal.py
@@ -6,53 +6,53 @@ from yaml_to_disk.yaml_to_disk import Directory, File, YamlDisk
 
 
 def test_is_yaml_file():
-    assert YamlDisk._is_yaml_file('foo.yaml')
-    assert YamlDisk._is_yaml_file('foo.yml')
-    assert not YamlDisk._is_yaml_file('foo.txt')
+    assert YamlDisk._is_yaml_file("foo.yaml")
+    assert YamlDisk._is_yaml_file("foo.yml")
+    assert not YamlDisk._is_yaml_file("foo.txt")
     with pytest.raises(TypeError):
         YamlDisk._is_yaml_file(1)  # type: ignore[arg-type]
 
 
 def test_read_yaml_file(tmp_path: Path):
-    fp = tmp_path / 'cfg.yaml'
-    fp.write_text('a: 1')
-    assert YamlDisk._read_yaml_file(fp) == {'a': 1}
+    fp = tmp_path / "cfg.yaml"
+    fp.write_text("a: 1")
+    assert YamlDisk._read_yaml_file(fp) == {"a": 1}
     with pytest.raises(FileNotFoundError):
-        YamlDisk._read_yaml_file(tmp_path / 'missing.yaml')
+        YamlDisk._read_yaml_file(tmp_path / "missing.yaml")
 
 
 def test_parse_yaml_contents_and_write(tmp_path: Path):
     yaml_data = {
-        'dir/': {'a.txt': 'hi'},
-        'b.txt': 'bye',
+        "dir/": {"a.txt": "hi"},
+        "b.txt": "bye",
     }
     parsed = YamlDisk._parse_yaml_contents(yaml_data)
     assert len(parsed) == 2
     dir_entry = next(p for p in parsed if isinstance(p, Directory))
-    file_entry = next(p for p in parsed if isinstance(p, File) and p.rel_path.name == 'b.txt')
+    file_entry = next(p for p in parsed if isinstance(p, File) and p.rel_path.name == "b.txt")
 
     dir_entry.write(tmp_path)
     file_entry.write(tmp_path)
 
-    assert (tmp_path / 'dir' / 'a.txt').read_text() == 'hi'
-    assert (tmp_path / 'b.txt').read_text() == 'bye'
+    assert (tmp_path / "dir" / "a.txt").read_text() == "hi"
+    assert (tmp_path / "b.txt").read_text() == "bye"
 
 
 def test_file_write_errors(tmp_path: Path):
-    file = File(Path('foo.txt'), 'bar')
+    file = File(Path("foo.txt"), "bar")
     file.write(tmp_path)
     with pytest.raises(FileExistsError):
         file.write(tmp_path)
     file.write(tmp_path, do_overwrite=True)
-    (tmp_path / 'dir').mkdir()
+    (tmp_path / "dir").mkdir()
     with pytest.raises(FileExistsError):
-        File(Path('dir'), 'x').write(tmp_path)
+        File(Path("dir"), "x").write(tmp_path)
     with pytest.raises(IsADirectoryError):
-        File(Path('dir'), 'x').write(tmp_path, do_overwrite=True)
+        File(Path("dir"), "x").write(tmp_path, do_overwrite=True)
 
 
 def test_directory_write_errors(tmp_path: Path):
-    (tmp_path / 'afile').write_text('x')
-    dir_entry = Directory(Path('afile'), [])
+    (tmp_path / "a_file").write_text("x")
+    dir_entry = Directory(Path("a_file"), [])
     with pytest.raises(NotADirectoryError):
         dir_entry.write(tmp_path)

--- a/tests/test_yaml_disk_internal.py
+++ b/tests/test_yaml_disk_internal.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+from yaml_to_disk.yaml_to_disk import Directory, File, YamlDisk
+
+
+def test_is_yaml_file():
+    assert YamlDisk._is_yaml_file('foo.yaml')
+    assert YamlDisk._is_yaml_file('foo.yml')
+    assert not YamlDisk._is_yaml_file('foo.txt')
+    with pytest.raises(TypeError):
+        YamlDisk._is_yaml_file(1)  # type: ignore[arg-type]
+
+
+def test_read_yaml_file(tmp_path: Path):
+    fp = tmp_path / 'cfg.yaml'
+    fp.write_text('a: 1')
+    assert YamlDisk._read_yaml_file(fp) == {'a': 1}
+    with pytest.raises(FileNotFoundError):
+        YamlDisk._read_yaml_file(tmp_path / 'missing.yaml')
+
+
+def test_parse_yaml_contents_and_write(tmp_path: Path):
+    yaml_data = {
+        'dir/': {'a.txt': 'hi'},
+        'b.txt': 'bye',
+    }
+    parsed = YamlDisk._parse_yaml_contents(yaml_data)
+    assert len(parsed) == 2
+    dir_entry = next(p for p in parsed if isinstance(p, Directory))
+    file_entry = next(p for p in parsed if isinstance(p, File) and p.rel_path.name == 'b.txt')
+
+    dir_entry.write(tmp_path)
+    file_entry.write(tmp_path)
+
+    assert (tmp_path / 'dir' / 'a.txt').read_text() == 'hi'
+    assert (tmp_path / 'b.txt').read_text() == 'bye'
+
+
+def test_file_write_errors(tmp_path: Path):
+    file = File(Path('foo.txt'), 'bar')
+    file.write(tmp_path)
+    with pytest.raises(FileExistsError):
+        file.write(tmp_path)
+    file.write(tmp_path, do_overwrite=True)
+    (tmp_path / 'dir').mkdir()
+    with pytest.raises(FileExistsError):
+        File(Path('dir'), 'x').write(tmp_path)
+    with pytest.raises(IsADirectoryError):
+        File(Path('dir'), 'x').write(tmp_path, do_overwrite=True)
+
+
+def test_directory_write_errors(tmp_path: Path):
+    (tmp_path / 'afile').write_text('x')
+    dir_entry = Directory(Path('afile'), [])
+    with pytest.raises(NotADirectoryError):
+        dir_entry.write(tmp_path)


### PR DESCRIPTION
## Summary
- remove FILE_TYPE_MATCHER usage in file type doctests
- show how each FileType uses its `matches` method

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847010c49fc832c92bdc73e08475552