### PR TITLE
Add Context7 documentation indexing (opt-in)

### DIFF
--- a/.github/workflows/context7-refresh.yaml
+++ b/.github/workflows/context7-refresh.yaml
@@ -6,10 +6,10 @@ on:
     branches:
       - main
     paths:
-      - 'README.md'
-      - 'src/**/*.py'
-      - 'context7.json'
-      - '.github/workflows/context7-refresh.yaml'
+      - "README.md"
+      - "src/**/*.py"
+      - "context7.json"
+      - ".github/workflows/context7-refresh.yaml"
 
 jobs:
   refresh:

--- a/.github/workflows/context7-refresh.yaml
+++ b/.github/workflows/context7-refresh.yaml
@@ -1,0 +1,25 @@
+name: Refresh Context7 Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'README.md'
+      - 'src/**/*.py'
+      - 'context7.json'
+      - '.github/workflows/context7-refresh.yaml'
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Context7 refresh
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --url https://context7.com/api/v1/refresh \
+            --header "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
+            --header "Content-Type: application/json" \
+            --data '{"libraryName":"/${{ github.repository }}"}'

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "yaml_to_disk",
+  "description": "Materialize directory trees from YAML for tests and fixtures. Inverse-friendly format supports YAML strings, YAML files, Python dicts, and Python lists as input, with a pluggable file-type system for .txt, .json, .yaml, .csv, .tsv, .toml, .parquet, and .pkl outputs.",
+  "folders": ["src/yaml_to_disk"],
+  "excludeFolders": ["tests"],
+  "rules": [
+    "Prefer the pre-constructed singleton `yaml_disk` (lowercase) over instantiating `YamlDisk()` directly.",
+    "Use `yaml_disk` as a context manager for ephemeral fixtures: `with yaml_disk(data) as root: ...` creates a temp directory that is cleaned up on exit.",
+    "Use `yaml_disk(data, root_dir=...)` for persistent writes into an existing directory; `root_dir` may be a string or `pathlib.Path`.",
+    "Installing this package auto-registers `yaml_disk` as a pytest doctest-namespace fixture. No imports are needed inside doctests once the package is installed.",
+    "Directory vs. file disambiguation in YAML input: a key ending in `/` is always a directory; a key without a suffix is a directory only when its contents are a dict or list (scalar contents are written as a file via the `.txt` fallback).",
+    "Supported file types register via the `yaml_to_disk.file_types` entry-point group. Each `FileType` subclass defines an `extension` class variable plus `validate` and `write` classmethods; adding a new extension is a matter of publishing a `FileType` subclass under that entry point.",
+    "Optional file-type dependencies are gated: `pyarrow` is required for `.parquet`, `tomli-w` is required for `.toml`. Both are lazily imported so the base install stays minimal.",
+    "Validation errors raise `ValueError`; pre-existing-file conflicts raise `FileExistsError` unless `do_overwrite=True` is passed; trying to overwrite a directory with a file still raises `IsADirectoryError` by design."
+  ]
+}


### PR DESCRIPTION
## Summary

Refs #14

Implements Option 3 from the design discussion on #14: the refresh workflow plus a `context7.json` pointing at `src/yaml_to_disk/` so the doctest-based documentation story gets indexed alongside the README.

- `context7.json` — scopes indexing to `src/yaml_to_disk`, excludes tests, and includes a `rules` block capturing the three gotchas most likely to be missed by LLM tooling (singleton preference, pytest fixture auto-registration, directory-vs-file disambiguation for extensionless names).
- `.github/workflows/context7-refresh.yaml` — triggers on pushes to `main` that touch documentation-relevant paths (`README.md`, `src/**/*.py`, `context7.json`, the workflow itself) plus manual `workflow_dispatch`. No automated submission workflow.

## :warning: Setup required before merging

This PR is intentionally blocked on maintainer action. Merging it before the steps below are complete will produce failing Actions runs on every docs-touching commit to `main` until the secret is in place and the library is registered.

**Maintainer steps required:**

1. **Decide to opt in.** Confirm you want Context7 indexing for this repo. The discussion on #14 noted this is a small-surface library where the upside is modest; the maintenance cost is real (secret rotation, Context7 API churn).
2. **Get a Context7 API key.** Sign in at https://context7.com, generate a key scoped to this library (or account-wide).
3. **Add the repo secret.** In `Settings → Secrets and variables → Actions`, add `CONTEXT7_API_KEY` with the key from step 2.
4. **Register the library with Context7.** The issue proposal suggested either (a) using the Context7 UI once, or (b) automating it via a one-time `workflow_dispatch` submission workflow. I've gone with (a) — it's one click and the automation has no ongoing value. From the Context7 UI, add a new library pointing at `https://github.com/mmcdermott/yaml_to_disk`.
5. **Verify the first refresh.** After merge, either push a docs-touching commit or run the workflow manually via `Actions → Refresh Context7 Docs → Run workflow`. Check that the request returns 200 and the library reflects the latest README/docstring content.

## What was deliberately **not** included

- **No `llms.txt`.** The README + doctests already serve that discovery purpose; `llms.txt` would be another file to keep in sync.
- **No automated submit workflow.** One-time UI submission is simpler and avoids the `release`/`workflow_dispatch` trigger maintenance.
- **No `context7.json` entries for compiled docs or examples/.** There is no `docs/` or `examples/` tree in this repo.

## Test plan

- [x] `uv run pytest --cov=yaml_to_disk` — 45 passed, 100% coverage retained (no code changes, but verifying the new JSON + YAML files don't confuse pytest's doctest collectors).
- [x] Workflow YAML parses cleanly — `yaml.safe_load` round-trip.
- [ ] **Requires maintainer:** `CONTEXT7_API_KEY` secret added; library registered in the Context7 UI.
- [ ] **Post-merge smoke test:** manually run `Refresh Context7 Docs` from the Actions tab and confirm a 200 response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)